### PR TITLE
converting links to https

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,13 +9,13 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
    
 
-    <meta property="og:url" content="http://devprogress.us/" />
+    <meta property="og:url" content="//devprogress.us/" />
     <meta property="og:title" content="DevProgress" />
     <meta property="og:description" content="We are volunteers using our skills and expertise to create tech tools to help elect Hillary Clinton and other Democratic and progressive candidates. We are coders, designers, leaders, writers, mentors, and researchers. Each project we work on focuses on an app, service, data resource, or other technology to advance the cause. We are a team — join us!" />
-    <meta property="og:image" content="http://devprogress.us/assets/img/dev-progress-logo.svg" />
+    <meta property="og:image" content="//devprogress.us/assets/img/dev-progress-logo.svg" />
 
-    <link href="http://www.google-analytics.com/" rel="dns-prefetch">
-    <link href="http://ajax.googleapis.com/" rel="dns-prefetch">
+    <link href="https://www.google-analytics.com/" rel="dns-prefetch">
+    <link href="https://ajax.googleapis.com/" rel="dns-prefetch">
     <link href="assets/css/style.min.css" rel="stylesheet">
     <link href="assets/css/style.css" rel="stylesheet">
 
@@ -186,7 +186,7 @@
                     </p>
 
                     <p>
-                A: If you have specific bugs or issues you want to report on a DevProgress project, you should check our <a target="_blank" href="http://github.com/devprogress">GitHub</a> Organization, locate the upstream project repository, and file the issues there directly.
+                A: If you have specific bugs or issues you want to report on a DevProgress project, you should check our <a target="_blank" href="https://github.com/devprogress">GitHub</a> Organization, locate the upstream project repository, and file the issues there directly.
                 </p>
 
                 <p>
@@ -234,7 +234,7 @@
                     <li>Who should we talk to to better understand the problem and current practice?</li>
                 </ol>
 
-                <p>All of our DevProgress community and campaign projects under active development can be found listed within the <a target="_blank" href="http://github.com/devprogress">DevProgress GitHub Organization</a></p>
+                <p>All of our DevProgress community and campaign projects under active development can be found listed within the <a target="_blank" href="https://github.com/devprogress">DevProgress GitHub Organization</a></p>
               </div>
             </div>
           </div>
@@ -278,7 +278,7 @@
                 </ul>
 
                 <p>
-                The source can be found on our <a target="_blank" href="http://github.com/devprogress/code-of-conduct">GitHub repo</a>.
+                The source can be found on our <a target="_blank" href="https://github.com/devprogress/code-of-conduct">GitHub repo</a>.
                 </p>
               </div>
             </div>
@@ -302,7 +302,7 @@
               <div class="col-sm-3 social-section">
                 <p class="section-header">Share</p>
                 <ul class="external-links list-unstyled">
-                  <li><div class="fb-share-button" data-href="http://devprogress.us" data-layout="button" data-size="small" data-mobile-iframe="true"><a class="fb-xfbml-parse-ignore" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fdevprogress.us%2F&amp;src=sdkpreparse">Facebook</a></div>
+                  <li><div class="fb-share-button" data-href="//devprogress.us" data-layout="button" data-size="small" data-mobile-iframe="true"><a class="fb-xfbml-parse-ignore" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fdevprogress.us%2F&amp;src=sdkpreparse">Facebook</a></div>
                   <li><div><a href="https://twitter.com/share" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
                   </div>
                 </ul>
@@ -320,7 +320,7 @@
       </section>
     </main>
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="assets/components/jquery.js"><\/script>');</script>
     <script src="assets/js/scripts.min.js"></script>
 


### PR DESCRIPTION
Just as the title says, if we transition the website to TLS, the static content, and links should also be TLS to avoid mixed content warnings and errors
